### PR TITLE
当多个项目在一个workspace下面时, 被合并的css文件名相同时, 不方便快速打开,不同项目用各自的名称比较容易分辨.

### DIFF
--- a/src/ispriter.js
+++ b/src/ispriter.js
@@ -1154,7 +1154,7 @@ function combineSpriteTasks(spriteTaskArray){
         combinedSpriteTask;
 
     //combinedFileName = DEFAULT_COMBINE_CSS_NAME;
-    //output.combine  扩展配置类型, 可以指定输出的文件名, 如: "combine": "exam_all.css"
+    //output.combine  扩展配置类型, 可以指定输出的文件名, 如: "combine": "exam_all.css" , 精灵图则为: sprite_exam_all.png
     combinedFileName = typeof spriteConfig.output.combine == 'string' ?  spriteConfig.output.combine : DEFAULT_COMBINE_CSS_NAME ;
     // combineFileName = path.resolve(combineFileName);
 


### PR DESCRIPTION
没有做扩展名判断, 个人觉得没太大必要
