### PR TITLE
Update ispriter.js

### DIFF
--- a/src/ispriter.js
+++ b/src/ispriter.js
@@ -633,6 +633,10 @@ function collectStyleRules(styleSheet, result, styleSheetUrl) {
             }
             result[imageUrl].cssRules.push(style);
         }
+        else{
+           //图片找不到css_backgound合并还原  20150405
+           style.mergeBackgound();
+        }
     });
     return result;
 }


### PR DESCRIPTION
取图片imageUrl地址失败再执行mergeBackgound合并background 。
解决网络图片等异常情况不需要合并图片时，css反而变长。
例如.aaa{background: transparent url("http://www.qjk.com/img/bg1.png") no-repeat scroll;
}合并反而变成如下的bug。
.aaa {background-image: url("http://www.qjk.com/img/bg1.png"); background-repeat: no-repeat; background-attachment: scroll; background-color: transparent;}