### PR TITLE
Update ispriter.js

### DIFF
--- a/src/ispriter.js
+++ b/src/ispriter.js
@@ -426,7 +426,9 @@ var BaseCSSStyleDeclaration = {
     mergeBackgound: function() {
         var background = '',
             style = this;
-
+        if(style.getPropertyValue('background')) {
+			return;
+		}
         var positionText = this.removeProperty('background-position-x') + ' ' +
             this.removeProperty('background-position-y');
 
@@ -442,7 +444,9 @@ var BaseCSSStyleDeclaration = {
                 background += this.removeProperty(item) + ' ';
             }
         }
-        style.setProperty('background', background.trim(), null);
+        if(background.trim()) {
+            style.setProperty('background', background.trim(), null);
+        }
     },
 
     /**


### PR DESCRIPTION
1、拆分splitBackground成功后background没有值才需要还原，有值的证明不需要还原。
2、background有值才需要压缩
sorry，昨天的bug改错了，会产生二个bug（1、会导致没有background加上了属性为空的background；2、仅有color的background缺失color。）重新修改。附测试例子
.s{
background:#5f5f5f;
top:0px; left:0px;}
.s1{
background:url('http://www.baidu.com/images/menu_bg.PNG') repeat-y;
top:0px; left:0px;}
.s2{
top:0px; left:0px;}